### PR TITLE
Add target token registration process

### DIFF
--- a/evm/src/circle_integration/CircleIntegration.sol
+++ b/evm/src/circle_integration/CircleIntegration.sol
@@ -51,7 +51,7 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
         bytes memory encodedMessage = encodeWormholeDepositWithPayload(
             WormholeDepositWithPayload({
                 payloadId: uint8(1),
-                token: addressToBytes32(token),
+                token: addressToBytes32(targetAcceptedToken(token, targetChain)),
                 amount: amountReceived,
                 sourceDomain: getChainDomain(chainId()),
                 targetDomain: getChainDomain(targetChain),

--- a/evm/src/circle_integration/CircleIntegrationGetters.sol
+++ b/evm/src/circle_integration/CircleIntegrationGetters.sol
@@ -48,6 +48,10 @@ contract CircleIntegrationGetters is CircleIntegrationSetters {
         return _state.acceptedTokens[token];
     }
 
+    function targetAcceptedToken(address sourceToken, uint16 chainId_) public view returns (address) {
+        return _state.targetAcceptedTokens[sourceToken][chainId_];
+    }
+
     function getChainDomain(uint16 chainId_) public view returns (uint32) {
         return _state.chainDomains[chainId_];
     }

--- a/evm/src/circle_integration/CircleIntegrationGovernance.sol
+++ b/evm/src/circle_integration/CircleIntegrationGovernance.sol
@@ -112,6 +112,13 @@ contract CircleIntegrationGovernance is CircleIntegrationGetters, ERC1967Upgrade
         addAcceptedToken(token);
     }
 
+    function registerTargetChainToken(address sourceToken, uint16 chainId_, address targetToken) public onlyOwner {
+        require(isAcceptedToken(sourceToken), "token not accepted");
+
+        // update the targetAcceptedTokens mapping
+        addTargetAcceptedToken(sourceToken, chainId_, targetToken);
+    }
+
     modifier onlyOwner() {
         require(owner() == msg.sender, "caller not the owner");
         _;

--- a/evm/src/circle_integration/CircleIntegrationSetters.sol
+++ b/evm/src/circle_integration/CircleIntegrationSetters.sol
@@ -44,6 +44,10 @@ contract CircleIntegrationSetters is CircleIntegrationState {
         _state.acceptedTokens[token] = true;
     }
 
+    function addTargetAcceptedToken(address sourceToken, uint16 chainId, address targetToken) internal {
+        _state.targetAcceptedTokens[sourceToken][chainId] = targetToken;
+    }
+
     function setChainDomain(uint16 chainId_, uint32 domain) internal {
         _state.chainDomains[chainId_] = domain;
     }

--- a/evm/src/circle_integration/CircleIntegrationState.sol
+++ b/evm/src/circle_integration/CircleIntegrationState.sol
@@ -36,6 +36,9 @@ contract CircleIntegrationStorage {
         // Circle Bridge accepted tokens
         mapping(address => bool) acceptedTokens;
 
+        // Cricle Bridge accepted token to target chain accepted token
+        mapping(address => mapping(uint16 => address)) targetAcceptedTokens;
+
         // Wormhole chain ID to USDC Chain Domain Mapping
         mapping(uint16 => uint32) chainDomains;
 


### PR DESCRIPTION
The purpose of this PR is to change the token address that in encoded in the `WormholeDepositWithPayload` message to the address of the token on the target chain. This requires adding an additional method to register the target chain token address on the source chain contract. 