### PR TITLE
Add fromAddress to WormholeDepositWithPayload message

### DIFF
--- a/evm/src/circle_integration/CircleIntegration.sol
+++ b/evm/src/circle_integration/CircleIntegration.sol
@@ -53,8 +53,8 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
                 payloadId: uint8(1),
                 token: addressToBytes32(targetAcceptedToken(token, targetChain)),
                 amount: amountReceived,
-                sourceDomain: getChainDomain(chainId()),
-                targetDomain: getChainDomain(targetChain),
+                sourceDomain: getDomainFromChainId(chainId()),
+                targetDomain: getDomainFromChainId(targetChain),
                 nonce: nonce,
                 fromAddress: addressToBytes32(msg.sender),
                 mintRecipient: mintRecipient,
@@ -103,7 +103,7 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
         // burn USDC on the bridge
         nonce = circleBridge.depositForBurnWithCaller(
             amountReceived,
-            getChainDomain(targetChain),
+            getDomainFromChainId(targetChain),
             mintRecipient,
             token,
             getRegisteredEmitter(targetChain)

--- a/evm/src/circle_integration/CircleIntegration.sol
+++ b/evm/src/circle_integration/CircleIntegration.sol
@@ -56,6 +56,7 @@ contract CircleIntegration is CircleIntegrationMessages, CircleIntegrationGovern
                 sourceDomain: getChainDomain(chainId()),
                 targetDomain: getChainDomain(targetChain),
                 nonce: nonce,
+                fromAddress: addressToBytes32(msg.sender),
                 mintRecipient: mintRecipient,
                 payload: payload
             })

--- a/evm/src/circle_integration/CircleIntegrationGetters.sol
+++ b/evm/src/circle_integration/CircleIntegrationGetters.sol
@@ -56,7 +56,7 @@ contract CircleIntegrationGetters is CircleIntegrationSetters {
         return _state.chainIdToDomain[chainId_];
     }
 
-    function getChainIdFromDomain(uint16 domain) public view returns (uint16) {
+    function getChainIdFromDomain(uint32 domain) public view returns (uint16) {
         return _state.domainToChainId[domain];
     }
 

--- a/evm/src/circle_integration/CircleIntegrationGetters.sol
+++ b/evm/src/circle_integration/CircleIntegrationGetters.sol
@@ -52,8 +52,12 @@ contract CircleIntegrationGetters is CircleIntegrationSetters {
         return _state.targetAcceptedTokens[sourceToken][chainId_];
     }
 
-    function getChainDomain(uint16 chainId_) public view returns (uint32) {
-        return _state.chainDomains[chainId_];
+    function getDomainFromChainId(uint16 chainId_) public view returns (uint32) {
+        return _state.chainIdToDomain[chainId_];
+    }
+
+    function getChainIdFromDomain(uint16 domain) public view returns (uint16) {
+        return _state.domainToChainId[domain];
     }
 
     function isMessageConsumed(bytes32 hash) public view returns (bool) {

--- a/evm/src/circle_integration/CircleIntegrationGovernance.sol
+++ b/evm/src/circle_integration/CircleIntegrationGovernance.sol
@@ -101,8 +101,9 @@ contract CircleIntegrationGovernance is CircleIntegrationGetters, ERC1967Upgrade
 
     /// @dev registerChainDomain serves to save the USDC Bridge chain domains
     function registerChainDomain(uint16 chainId_, uint32 domain) public onlyOwner {
-        // update the chainDomains state variable
-        setChainDomain(chainId_, domain);
+        // update the chainId to domain (and domain to chainId) mappings
+        setChainIdToDomain(chainId_, domain);
+        setDomainToChainId(domain, chainId_);
     }
 
     /// @dev addAcceptedToken serves to determine which tokens can be burned + minted

--- a/evm/src/circle_integration/CircleIntegrationMessages.sol
+++ b/evm/src/circle_integration/CircleIntegrationMessages.sol
@@ -18,6 +18,7 @@ contract CircleIntegrationMessages is CircleIntegrationStructs {
             message.sourceDomain,
             message.targetDomain,
             message.nonce,
+            message.fromAddress,
             message.mintRecipient,
             message.payload.length,
             message.payload
@@ -54,6 +55,10 @@ contract CircleIntegrationMessages is CircleIntegrationStructs {
         // nonce
         message.nonce = encoded.toUint64(index);
         index += 8;
+
+        // fromAddress (contract caller)
+        message.fromAddress = encoded.toBytes32(index);
+        index += 32;
 
         // mintRecipient (target contract)
         message.mintRecipient = encoded.toBytes32(index);

--- a/evm/src/circle_integration/CircleIntegrationSetters.sol
+++ b/evm/src/circle_integration/CircleIntegrationSetters.sol
@@ -48,8 +48,12 @@ contract CircleIntegrationSetters is CircleIntegrationState {
         _state.targetAcceptedTokens[sourceToken][chainId] = targetToken;
     }
 
-    function setChainDomain(uint16 chainId_, uint32 domain) internal {
-        _state.chainDomains[chainId_] = domain;
+    function setChainIdToDomain(uint16 chainId_, uint32 domain) internal {
+        _state.chainIdToDomain[chainId_] = domain;
+    }
+
+    function setDomainToChainId(uint32 domain, uint16 chainId_) internal {
+        _state.domainToChainId[domain] = chainId_;
     }
 
     function consumeMessage(bytes32 hash) internal {

--- a/evm/src/circle_integration/CircleIntegrationState.sol
+++ b/evm/src/circle_integration/CircleIntegrationState.sol
@@ -40,7 +40,10 @@ contract CircleIntegrationStorage {
         mapping(address => mapping(uint16 => address)) targetAcceptedTokens;
 
         // Wormhole chain ID to USDC Chain Domain Mapping
-        mapping(uint16 => uint32) chainDomains;
+        mapping(uint16 => uint32) chainIdToDomain;
+
+        // Wormhole chain ID to USDC Chain Domain Mapping
+        mapping(uint32 => uint16) domainToChainId;
 
         // verified message hash to boolean
         mapping(bytes32 => bool) consumedMessages;

--- a/evm/src/circle_integration/CircleIntegrationStructs.sol
+++ b/evm/src/circle_integration/CircleIntegrationStructs.sol
@@ -15,6 +15,7 @@ contract CircleIntegrationStructs {
         uint32 sourceDomain;
         uint32 targetDomain;
         uint64 nonce;
+        bytes32 fromAddress;
         bytes32 mintRecipient;
         bytes payload;
     }

--- a/evm/src/interfaces/ICircleIntegration.sol
+++ b/evm/src/interfaces/ICircleIntegration.sol
@@ -82,7 +82,9 @@ interface ICircleIntegration {
 
     function isAcceptedToken(address token) external view returns (bool);
 
-    function getChainDomain(uint16 chainId_) external view returns (uint32);
+    function getDomainFromChainId(uint16 chainId_) external view returns (uint32);
+
+    function getChainIdFromDomain(uint32 domain) external view returns (uint16);
 
     function isMessageConsumed(bytes32 hash) external view returns (bool);
 }

--- a/evm/src/interfaces/ICircleIntegration.sol
+++ b/evm/src/interfaces/ICircleIntegration.sol
@@ -20,6 +20,7 @@ interface ICircleIntegration {
         uint32 sourceDomain;
         uint32 targetDomain;
         uint64 nonce;
+        bytes32 fromAddress;
         bytes32 mintRecipient;
         bytes payload;
     }


### PR DESCRIPTION
The purpose of this PR is to add the `fromAddress` to the `WormholeDepositWithPayload` message. Composing contracts currently don't have a good way to verify that they are receiving a message originating from a trusted contract. 

This PR also adds an additional getter method which allows integrators to query for the Wormhole chainId by passing the Circle chain domain as an argument. 