### PR TITLE
Add TransferParameters struct with batchId

### DIFF
--- a/evm/src/circle_integration/CircleIntegrationStructs.sol
+++ b/evm/src/circle_integration/CircleIntegrationStructs.sol
@@ -2,6 +2,13 @@
 pragma solidity ^0.8.13;
 
 contract CircleIntegrationStructs {
+    struct TransferParameters {
+        address token;
+        uint256 amount;
+        uint16 targetChain;
+        bytes32 mintRecipient;
+    }
+
     struct RedeemParameters {
         bytes encodedWormholeMessage;
         bytes circleBridgeMessage;

--- a/evm/src/interfaces/ICircleIntegration.sol
+++ b/evm/src/interfaces/ICircleIntegration.sol
@@ -7,6 +7,13 @@ import {ICircleBridge} from "./circle/ICircleBridge.sol";
 import {IMessageTransmitter} from "./circle/IMessageTransmitter.sol";
 
 interface ICircleIntegration {
+    struct TransferParameters {
+        address token;
+        uint256 amount;
+        uint16 targetChain;
+        bytes32 mintRecipient;
+    }
+
     struct RedeemParameters {
         bytes encodedWormholeMessage;
         bytes circleBridgeMessage;
@@ -39,10 +46,8 @@ interface ICircleIntegration {
     }
 
     function transferTokensWithPayload(
-        address token,
-        uint256 amount,
-        uint16 targetChain,
-        bytes32 mintRecipient,
+        TransferParameters memory transferParams,
+        uint32 batchId,
         bytes memory payload
     ) external payable returns (uint64 messageSequence);
 


### PR DESCRIPTION
The purpose of this PR is to add a configurable `batchId` to `transferTokensWithPayload`. This will allow composing contracts to batch transfers with other Wormhole messages in the future. 